### PR TITLE
Make sure we're using the right zip asset

### DIFF
--- a/src/Exception/NoZipAssetException.php
+++ b/src/Exception/NoZipAssetException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use Exception;
+
+class NoZipAssetException extends Exception
+{
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since we're also putting an xml file as a release asset, it might be used instead of the zip, leading to exceptions when the script needs the zip later on.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | [preprod-api](https://preprod-api.prestashop-project.org/prestashop) should return PrestaShop 8.0.1
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
