### PR TITLE
Fix uniqueness of PrestaShop versions

### DIFF
--- a/src/Command/GenerateJsonCommand.php
+++ b/src/Command/GenerateJsonCommand.php
@@ -35,9 +35,11 @@ class GenerateJsonCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $modules = $this->moduleUtils->getLocalModules();
-        $prestashopVersions = array_merge(
-            $this->prestaShopUtils->getVersionsFromBucket(),
-            $this->prestaShopUtils->getLocalVersions()
+        $prestashopVersions = $this->prestaShopUtils->getLocalVersions() + $this->prestaShopUtils->getVersionsFromBucket();
+        // Remove duplicates by comparing the version
+        $prestashopVersions = array_intersect_key(
+            $prestashopVersions,
+            array_unique(array_map(fn ($item) => $item->getVersion(), $prestashopVersions))
         );
 
         if (count($modules) === 0 || empty($prestashopVersions)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Because of a wrong way of removing version duplicates, in some cases, multiple entry of the same PrestaShop version could be added to the prestahop.json file. This PR aims to fix this by changing the way uniqueness is done.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/issues/30866
| How to test?      | Not ready yet but will be: See that after multiple runs, [https://integration-api.prestashop-project.org/prestashop](https://integration-api.prestashop-project.org/prestashop) doesn't contain duplicate versions of PrestaShop
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
