### PR TITLE
Added filter on prerelease versions

### DIFF
--- a/src/Util/ModuleUtils.php
+++ b/src/Util/ModuleUtils.php
@@ -60,7 +60,7 @@ class ModuleUtils
         while (count($results = $releasesApi->all('PrestaShop', $moduleName, ['page' => $page++])) > 0) {
             $versions = array_merge(
                 $versions,
-                array_filter($results, fn ($item) => (!empty($item['assets'] || !$withAssetOnly) && !$item['draft']))
+                array_filter($results, fn ($item) => (!empty($item['assets'] || !$withAssetOnly) && (!$item['draft'] && !$item['prerelease'])))
             );
         }
 
@@ -227,7 +227,6 @@ class ModuleUtils
 
         /** @var array<string, array<string, string>> $files */
         $files = $this->githubClient->repository()->contents()->show($username, $repository);
-
         $modules = array_filter($files, fn ($item) => str_ends_with($item['name'], '.yml'));
 
         return array_map(fn ($item) => substr($item['name'], 0, -4), $modules);


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Today, we filter only on `draft` releases to avoid them on Distribution API. But we don't want to have `prerelease` too. 
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | PrestaShop
| How to test?      | See below


## How to test 

Before the PR, when you execute `bin/console downloadNativeModuleFiles`, you have these lines: 

```
Downloading psgdpr v2.0.0
Downloading psgdpr v1.4.3
```

After the PR, you have : 

```
Downloading psgdpr v1.4.3
``` 
