### PR TITLE
Don't rely on deprecated save-state and set-output commands

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2
@@ -90,7 +90,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
+        run: echo dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Apply https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | PrestaShop Corp
| How to test?      | CI should run as expected
