### PR TITLE
Automatically add next versions

### DIFF
--- a/src/Model/PrestaShop.php
+++ b/src/Model/PrestaShop.php
@@ -31,6 +31,67 @@ class PrestaShop implements JsonSerializable
         return $this->version;
     }
 
+    public function getNextMajorVersion(): string
+    {
+        return implode('.', [
+            $this->getMajorVersionNumber() + 1,
+            0,
+            0,
+        ]);
+    }
+
+    public function getNextMinorVersion(): string
+    {
+        return implode('.', [
+            $this->getMajorVersionNumber(),
+            $this->getMinorVersionNumber() + 1,
+            0,
+        ]);
+    }
+
+    public function getNextPatchVersion(): string
+    {
+        return implode('.', [
+            $this->getMajorVersionNumber(),
+            $this->getMinorVersionNumber(),
+            $this->getPatchVersionNumber() + 1,
+        ]);
+    }
+
+    public function getMajorVersionNumber(): int
+    {
+        $version = $this->stripExtraDataFromVersion($this->version);
+        $version = explode('.', $version);
+
+        return (int) $version[0];
+    }
+
+    public function getMinorVersionNumber(): int
+    {
+        $version = $this->stripExtraDataFromVersion($this->version);
+        $version = explode('.', $version);
+
+        return (int) $version[1];
+    }
+
+    public function getPatchVersionNumber(): int
+    {
+        $version = $this->stripExtraDataFromVersion($this->version);
+        $version = explode('.', $version);
+
+        return (int) $version[2];
+    }
+
+    private function stripExtraDataFromVersion(string $version): string
+    {
+        if (str_starts_with($version, '1.')) {
+            $version = substr($version, 2);
+        }
+        $version = explode('-', $version);
+
+        return $version[0];
+    }
+
     public function getMinPhpVersion(): ?string
     {
         return $this->minPhpVersion;

--- a/src/Util/VersionUtils.php
+++ b/src/Util/VersionUtils.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Util;
+
+use App\Model\PrestaShop;
+
+class VersionUtils
+{
+    /**
+     * Returns highest available stable version from a list of Prestashop versions.
+     * Ignores beta and release candidates.
+     *
+     * @param PrestaShop[] $list
+     *
+     * @return PrestaShop|null
+     */
+    public function getHighestStableVersionFromList(array $list = []): ?Prestashop
+    {
+        if (empty($list)) {
+            return null;
+        }
+
+        // Get highest version available
+        $highestVersion = null;
+        foreach ($list as $version) {
+            if (($highestVersion === null || version_compare($version->getVersion(), $highestVersion->getVersion(), '>')) &&
+              $version->isStable()) {
+                $highestVersion = $version;
+            }
+        }
+
+        return $highestVersion;
+    }
+
+    /**
+     * Returns highest available stable version of a previous major from a list of Prestashop versions.
+     * Ignores beta and release candidates.
+     *
+     * @param PrestaShop[] $list
+     *
+     * @return PrestaShop|null
+     */
+    public function getHighestStablePreviousVersionFromList(array $list = []): ?Prestashop
+    {
+        if (empty($list)) {
+            return null;
+        }
+
+        $highestVersion = $this->getHighestStableVersionFromList($list);
+
+        if (empty($highestVersion)) {
+            return null;
+        }
+
+        $possiblePreviousMajor = $highestVersion->getMajorVersionNumber() - 1;
+        $highestPreviousVersion = null;
+        foreach ($list as $version) {
+            if (($highestPreviousVersion === null || version_compare($version->getVersion(), $highestPreviousVersion->getVersion(), '>')) &&
+                $version->getMajorVersionNumber() == $possiblePreviousMajor &&
+                $version->isStable()) {
+                $highestPreviousVersion = $version;
+            }
+        }
+
+        return $highestPreviousVersion;
+    }
+}

--- a/tests/Command/GenerateJsonCommandTest.php
+++ b/tests/Command/GenerateJsonCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Command;
 
 use App\Command\GenerateJsonCommand;
+use App\Model\PrestaShop;
 use App\Util\ModuleUtils;
 use App\Util\PrestaShopUtils;
 use App\Util\PublicDownloadUrlProvider;
@@ -106,5 +107,64 @@ class GenerateJsonCommandTest extends AbstractCommandTestCase
             $baseExpected . '/prestashop/beta.json',
             $baseOutput . '/prestashop/beta.json'
         );
+    }
+
+    /**
+     * @dataProvider versionListProvider
+     */
+    public function testAddVersionsUnderDelopment(array $before, array $afterExpected)
+    {
+        $this->assertEquals($afterExpected, $this->command->addVersionsUnderDelopment($before));
+    }
+
+    public function versionListProvider(): iterable
+    {
+        // Pretty normal scenario
+        yield [[
+                new Prestashop('8.1.4'),
+                new Prestashop('8.1.3'),
+                new Prestashop('9.0.0'),
+                new Prestashop('9.0.3'),
+                new Prestashop('1.7.8.10'),
+            ], [
+                new Prestashop('8.1.4'),
+                new Prestashop('8.1.3'),
+                new Prestashop('9.0.0'),
+                new Prestashop('9.0.3'),
+                new Prestashop('1.7.8.10'),
+                new Prestashop('10.0.0'),
+                new Prestashop('9.1.0'),
+                new Prestashop('9.0.4'),
+                new Prestashop('8.2.0'),
+                new Prestashop('8.1.5'),
+        ]];
+        // Scenario to avoid adding 1.7 versions as a previous major
+        yield [[
+            new Prestashop('8.1.4'),
+            new Prestashop('8.1.3'),
+            new Prestashop('1.7.8.10'),
+        ], [
+            new Prestashop('8.1.4'),
+            new Prestashop('8.1.3'),
+            new Prestashop('1.7.8.10'),
+            new Prestashop('9.0.0'),
+            new Prestashop('8.2.0'),
+            new Prestashop('8.1.5'),
+        ]];
+        // Scenario to avoid considering beta as a stable channel
+        yield [[
+            new Prestashop('8.1.4'),
+            new Prestashop('8.1.3'),
+            new Prestashop('9.0.0-beta'),
+            new Prestashop('1.7.8.10'),
+        ], [
+            new Prestashop('8.1.4'),
+            new Prestashop('8.1.3'),
+            new Prestashop('9.0.0-beta'),
+            new Prestashop('1.7.8.10'),
+            new Prestashop('9.0.0'),
+            new Prestashop('8.2.0'),
+            new Prestashop('8.1.5'),
+        ]];
     }
 }

--- a/tests/Model/PrestaShopTest.php
+++ b/tests/Model/PrestaShopTest.php
@@ -19,6 +19,28 @@ class PrestaShopTest extends TestCase
     }
 
     /**
+     * @dataProvider versionNumberProvider
+     */
+    public function testVersionNumber(string $version, int $expectedMajor, int $expectedMinor, int $expectedPatch)
+    {
+        $prestaShop = new PrestaShop($version);
+        $this->assertSame($expectedMajor, $prestaShop->getMajorVersionNumber());
+        $this->assertSame($expectedMinor, $prestaShop->getMinorVersionNumber());
+        $this->assertSame($expectedPatch, $prestaShop->getPatchVersionNumber());
+    }
+
+    /**
+     * @dataProvider nextVersionsProvider
+     */
+    public function testNextVersion(string $version, string $nextMajor, string $nextMinor, string $nextPatch)
+    {
+        $prestaShop = new PrestaShop($version);
+        $this->assertSame($nextMajor, $prestaShop->getNextMajorVersion());
+        $this->assertSame($nextMinor, $prestaShop->getNextMinorVersion());
+        $this->assertSame($nextPatch, $prestaShop->getNextPatchVersion());
+    }
+
+    /**
      * @dataProvider rcProvider
      */
     public function testIsRC(string $version, bool $expected)
@@ -76,5 +98,24 @@ class PrestaShopTest extends TestCase
         yield ['8.0.0-rc.2', false];
         yield ['8.0.0-beta.1', true];
         yield ['8.0.0-beta.2', true];
+    }
+
+    public function versionNumberProvider(): iterable
+    {
+        yield ['1.7.8.0', 7, 8, 0];
+        yield ['8.0.0', 8, 0, 0];
+        yield ['8.0.0-rc.1', 8, 0, 0];
+        yield ['8.0.0-beta.1', 8, 0, 0];
+        yield ['8.1.4', 8, 1, 4];
+    }
+
+    public function nextVersionsProvider(): iterable
+    {
+        yield ['1.7.8.0', '8.0.0', '7.9.0', '7.8.1'];
+        yield ['8.0.0', '9.0.0', '8.1.0', '8.0.1'];
+        yield ['8.0.0-rc.1', '9.0.0', '8.1.0', '8.0.1'];
+        yield ['8.0.0-beta.1', '9.0.0', '8.1.0', '8.0.1'];
+        yield ['8.1.4', '9.0.0', '8.2.0', '8.1.5'];
+        yield ['9.0.0', '10.0.0', '9.1.0', '9.0.1'];
     }
 }

--- a/tests/Util/VersionUtilsTest.php
+++ b/tests/Util/VersionUtilsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Util;
+
+use App\Model\PrestaShop;
+use App\Util\VersionUtils;
+use Tests\AbstractMockedGithubClientTestCase;
+
+class VersionUtilsTest extends AbstractMockedGithubClientTestCase
+{
+    public function testGetHighestStableVersionFromList()
+    {
+        $this->assertEquals(
+            new PrestaShop('9.0.3'),
+            (new VersionUtils())->getHighestStableVersionFromList([
+              new Prestashop('8.1.4'),
+              new Prestashop('8.1.3'),
+              new Prestashop('9.0.0'),
+              new Prestashop('9.0.3'),
+              new Prestashop('9.0.3'),
+              new Prestashop('1.7.8.10'),
+        ]));
+        $this->assertEquals(
+            new PrestaShop('8.1.4'),
+            (new VersionUtils())->getHighestStableVersionFromList([
+              new Prestashop('8.1.4'),
+              new Prestashop('8.1.3'),
+              new Prestashop('9.0.0-beta'),
+              new Prestashop('1.7.8.10'),
+        ]));
+    }
+
+    public function testGetHighestStableVersionFromListWithEmptyList()
+    {
+        $this->assertEquals(
+            null,
+            (new VersionUtils())->getHighestStableVersionFromList([
+        ]));
+    }
+
+    public function testGetHighestStablePreviousVersionFromList()
+    {
+        $this->assertEquals(
+            new PrestaShop('8.1.4'),
+            (new VersionUtils())->getHighestStablePreviousVersionFromList([
+              new Prestashop('8.1.4'),
+              new Prestashop('8.1.3'),
+              new Prestashop('9.0.0'),
+              new Prestashop('9.0.3'),
+              new Prestashop('9.0.3'),
+              new Prestashop('1.7.8.10'),
+        ]));
+        $this->assertEquals(
+            new PrestaShop('1.7.8.10'),
+            (new VersionUtils())->getHighestStablePreviousVersionFromList([
+              new Prestashop('8.1.4'),
+              new Prestashop('8.1.3'),
+              new Prestashop('9.0.0-beta'),
+              new Prestashop('1.7.8.10'),
+        ]));
+    }
+
+    public function testGetHighestStablePreviousVersionFromListWithEmptyList()
+    {
+        $this->assertEquals(
+            null,
+            (new VersionUtils())->getHighestStablePreviousVersionFromList([
+        ]));
+    }
+}


### PR DESCRIPTION
Replacement of https://github.com/PrestaShop/distribution-api/pull/39.

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Automatically creates endpoint for next major, patches of current major and patches for previous major.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | 

Before:
1.7.8.10
8.0.4
8.0.5
8.1.3
8.1.4
9.0.0

After:
1.7.8.10
8.0.4
8.0.5
8.1.3
8.1.4
9.0.0
**10.0.0 // Added
9.0.1 // Added
9.1.0 // Added
8.1.5 // Added
8.2.0 // Added**