### PR TITLE
Add new autoupgrade file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
-public/json/*
+public/json/prestashop
+public/json/prestashop.json
 !public/json/.gitkeep
 
 var/tmp/*

--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -1,0 +1,27 @@
+{
+  "prestashop": [
+    {
+      "prestashop_min": "1.7.0.0",
+      "prestashop_max": "8.2.1",
+      "autoupgrade_recommended": {
+        "last_version": "7.0.0",
+        "download": {
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.0.0/autoupgrade-v7.0.0.zip",
+          "md5": "c0d83aea9dbb03d7f2f698d011144d43"
+        },
+        "changelog": "https://build.prestashop-project.org/news/2025/autoupgrade-v7.0-release/"
+      }
+    },
+    {
+      "prestashop_min": "1.6.0.0",
+      "prestashop_max": "1.7.8.11",
+      "autoupgrade_recommended": {
+        "last_version": "4.16.4",
+        "download": {
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v4.16.4/autoupgrade.zip",
+          "md5": "3639dd7c9910f2805777cbcae129ef1a"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |Addition of a new file available in the API, autoupgrade.json, allowing you to know which version of PrestaShop is compatible with a specific version of the Autoupgrade module. This will have to be maintained following the release of the autoupgrade module
| Type?             | new feature 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -
