### PR TITLE
[FEAT] update workflows with latest version of actions

### DIFF
--- a/.github/workflows/ci-cd-integration.yml
+++ b/.github/workflows/ci-cd-integration.yml
@@ -18,14 +18,15 @@ jobs:
       - name: Checkout the repository 🎁
         uses: actions/checkout@v4
 
-      - name: 'Authenticating to GCP ⚙️'
-        uses: google-github-actions/auth@v1
+      - name: Authenticating to GCP ⚙️
+        uses: google-github-actions/auth@v2
         with:
-          project_id: core-oss-integration
           credentials_json: ${{ secrets.G_CREDENTIALS_INTEGRATION }}
 
-      - name: 'Setting up Cloud SDK 💳'
-        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Setting up google Cloud SDK 💳
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: core-oss-integration
 
       - name: Configure gcloud 👷
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
@@ -44,7 +45,7 @@ jobs:
           docker push europe-west1-docker.pkg.dev/core-oss-integration/distribution-api/distribution-api:${{ steps.get_tag.outputs.TAG }}
 
       - name: Trigger deploy 🚀
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: the-actions-org/workflow-dispatch@v4
         with:
           workflow: deployment-integration.yml
           repo: PrestaShopCorp/terraform-core-oss-distribution-api

--- a/.github/workflows/ci-cd-preproduction.yml
+++ b/.github/workflows/ci-cd-preproduction.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setting up google Cloud SDK 💳
         uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: core-oss-integration
+          project_id: core-oss-preproduction
 
       - name: Configure gcloud 👷
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev

--- a/.github/workflows/ci-cd-preproduction.yml
+++ b/.github/workflows/ci-cd-preproduction.yml
@@ -18,12 +18,15 @@ jobs:
       - name: Checkout the repository 🎁
         uses: actions/checkout@v4
 
-      - name: Setting up google Cloud SDK 💳
-        uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticating to GCP ⚙️
+        uses: google-github-actions/auth@v2
         with:
-          project_id: core-oss-preproduction
-          service_account_key: ${{ secrets.G_CREDENTIALS_PREPRODUCTION }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.G_CREDENTIALS_PREPRODUCTION }}
+
+      - name: Setting up google Cloud SDK 💳
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: core-oss-integration
 
       - name: Configure gcloud 👷
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
@@ -42,7 +45,7 @@ jobs:
           docker push europe-west1-docker.pkg.dev/core-oss-preproduction/distribution-api/distribution-api:${{ steps.get_tag.outputs.TAG }}
 
       - name: Trigger deploy 🚀
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: the-actions-org/workflow-dispatch@v4
         with:
           workflow: deployment-preproduction.yml
           repo: PrestaShopCorp/terraform-core-oss-distribution-api

--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setting up google Cloud SDK 💳
         uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: core-oss-integration
+          project_id: core-oss-production
 
       - name: Configure gcloud 👷
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev

--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -17,12 +17,15 @@ jobs:
       - name: Checkout the repository 🎁
         uses: actions/checkout@v4
 
-      - name: Setting up google Cloud SDK 💳
-        uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticating to GCP ⚙️
+        uses: google-github-actions/auth@v2
         with:
-          project_id: core-oss-production
-          service_account_key: ${{ secrets.G_CREDENTIALS_PRODUCTION }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.G_CREDENTIALS_PRODUCTION }}
+
+      - name: Setting up google Cloud SDK 💳
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: core-oss-integration
 
       - name: Configure gcloud 👷
         run: gcloud auth configure-docker europe-west1-docker.pkg.dev
@@ -41,7 +44,7 @@ jobs:
           docker push europe-west1-docker.pkg.dev/core-oss-production/distribution-api/distribution-api:${{ steps.get_tag.outputs.TAG }}
 
       - name: Trigger deploy 🚀
-        uses: aurelien-baudet/workflow-dispatch@v2
+        uses: the-actions-org/workflow-dispatch@v4
         with:
           workflow: deployment-production.yml
           repo: PrestaShopCorp/terraform-core-oss-distribution-api


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The "workflow-dispatch" and "setup-gcloud" actions are no longer up to date with the latest version and are deprecated. This PR updates these workflows.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | See workflow `ci-cd-integration` related to this PR => https://github.com/PrestaShop/distribution-api/actions/runs/14473575741/job/40593520934