### PR TITLE
[FIX] Switch to Symfony HttpClient for HTTP requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/finder": "^5.3",
         "symfony/yaml": "^5.3",
         "knplabs/github-api": "^3.3",
-        "google/cloud-storage": "^1.26"
+        "google/cloud-storage": "^1.26",
+        "symfony/http-client": "^5.3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": "^8.0",
         "ext-zip": "*",
-        "guzzlehttp/guzzle": "^7.9",
         "prestashop/psssst": "^1.2",
         "symfony/config": "^5.3",
         "symfony/console": "^5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dff2cbb46baa4d966de73353c2017a0",
+    "content-hash": "bf8f55ba5e8234701e545e4fc80f74ee",
     "packages": [
         {
             "name": "brick/math",
@@ -2771,6 +2771,175 @@
                 }
             ],
             "time": "2024-09-28T13:32:08+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v5.4.49",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "d77d8e212cde7b5c4a64142bf431522f19487c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/d77d8e212cde7b5c4a64142bf431522f19487c28",
+                "reference": "d77d8e212cde7b5c4a64142bf431522f19487c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/http-client-contracts": "^2.5.4",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.0|^2|^3"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "2.4"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "php-http/message-factory": "^1.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4.13|^5.1.5|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v5.4.49"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-28T08:37:04+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v2.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "48ef1d0a082885877b664332b9427662065a360c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/48ef1d0a082885877b664332b9427662065a360c",
+                "reference": "48ef1d0a082885877b664332b9427662065a360c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-28T08:37:04+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf8f55ba5e8234701e545e4fc80f74ee",
+    "content-hash": "a848f1bed3a124997dba6d6990abd41d",
     "packages": [
         {
             "name": "brick/math",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,6 +16,9 @@ services:
   Symfony\Component\Console\Application:
     public: true
 
+  Symfony\Contracts\HttpClient\HttpClientInterface:
+    factory: [ 'Symfony\Component\HttpClient\HttpClient', 'create' ]
+
   Github\Client:
     calls:
       - authenticate: ['%github_token%', 'access_token_header']

--- a/src/Util/ModuleUtils.php
+++ b/src/Util/ModuleUtils.php
@@ -9,10 +9,10 @@ use App\Model\Version;
 use App\ModuleCollection;
 use Github\Client as GithubClient;
 use Google\Cloud\Storage\Bucket;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Psssst\ModuleParser;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use ZipArchive;
 
 class ModuleUtils

--- a/src/Util/ModuleUtils.php
+++ b/src/Util/ModuleUtils.php
@@ -9,7 +9,7 @@ use App\Model\Version;
 use App\ModuleCollection;
 use Github\Client as GithubClient;
 use Google\Cloud\Storage\Bucket;
-use GuzzleHttp\Client;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Psssst\ModuleParser;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
@@ -21,7 +21,7 @@ class ModuleUtils
     private const GITHUB_MAIN_CLASS_ENDPOINT = 'https://raw.githubusercontent.com/PrestaShop/%s/%s/%s.php';
 
     private ModuleParser $parser;
-    private Client $client;
+    private HttpClientInterface $client;
     private GithubClient $githubClient;
     private Bucket $bucket;
     private PublicDownloadUrlProvider $publicDownloadUrlProvider;
@@ -31,7 +31,7 @@ class ModuleUtils
 
     public function __construct(
         ModuleParser $moduleParser,
-        Client $client,
+        HttpClientInterface $client,
         GithubClient $githubClient,
         Bucket $bucket,
         PublicDownloadUrlProvider $publicDownloadUrlProvider,
@@ -111,8 +111,8 @@ class ModuleUtils
             mkdir($path, 0777, true);
         }
 
-        $response = $this->client->get(sprintf(self::GITHUB_MAIN_CLASS_ENDPOINT, $moduleName, $version->getTag(), $moduleName), ['stream' => true]);
-        file_put_contents($path . '/' . $moduleName . '.php', $response->getBody());
+        $response = $this->client->request('GET', sprintf(self::GITHUB_MAIN_CLASS_ENDPOINT, $moduleName, $version->getTag(), $moduleName));
+        file_put_contents($path . '/' . $moduleName . '.php', $response->toStream());
     }
 
     public function download(string $moduleName, Version $version): void
@@ -126,8 +126,8 @@ class ModuleUtils
             throw new RuntimeException(sprintf('Unable to download %s %s because it has no Github url', $moduleName, $version->getTag()));
         }
 
-        $response = $this->client->get($version->getGithubUrl(), ['stream' => true]);
-        file_put_contents($path . '/' . $moduleName . '.zip', $response->getBody());
+        $response = $this->client->request('GET', $version->getGithubUrl());
+        file_put_contents($path . '/' . $moduleName . '.zip', $response->toStream());
     }
 
     public function extractLogo(string $moduleName, Version $version): void

--- a/src/Util/ModuleUtils.php
+++ b/src/Util/ModuleUtils.php
@@ -111,6 +111,7 @@ class ModuleUtils
             mkdir($path, 0777, true);
         }
 
+        /** @var \Symfony\Component\HttpClient\Response\StreamableInterface $response */
         $response = $this->client->request('GET', sprintf(self::GITHUB_MAIN_CLASS_ENDPOINT, $moduleName, $version->getTag(), $moduleName));
         file_put_contents($path . '/' . $moduleName . '.php', $response->toStream());
     }
@@ -126,6 +127,7 @@ class ModuleUtils
             throw new RuntimeException(sprintf('Unable to download %s %s because it has no Github url', $moduleName, $version->getTag()));
         }
 
+        /** @var \Symfony\Component\HttpClient\Response\StreamableInterface $response */
         $response = $this->client->request('GET', $version->getGithubUrl());
         file_put_contents($path . '/' . $moduleName . '.zip', $response->toStream());
     }

--- a/src/Util/PrestaShopUtils.php
+++ b/src/Util/PrestaShopUtils.php
@@ -15,6 +15,8 @@ use PhpParser\Node\Stmt;
 use PhpParser\ParserFactory;
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpClient\Response\StreamableInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Throwable;
 use ZipArchive;
@@ -52,6 +54,9 @@ class PrestaShopUtils
         $this->prestaShopDir = $prestaShopDir;
     }
 
+    /**
+     * @throws TransportExceptionInterface
+     */
     public function download(PrestaShop $prestaShop): void
     {
         $path = $this->prestaShopDir . '/' . $prestaShop->getVersion();
@@ -63,10 +68,12 @@ class PrestaShopUtils
             throw new RuntimeException(sprintf('Unable to download PrestaShop %s zip because it has no Github url', $prestaShop->getVersion()));
         }
 
+        /** @var StreamableInterface $response */
         $response = $this->client->request('GET', $prestaShop->getGithubZipUrl());
         file_put_contents($path . '/prestashop.zip', $response->toStream());
 
         if ($prestaShop->getGithubXmlUrl() !== null) {
+            /** @var StreamableInterface $response */
             $response = $this->client->request('GET', $prestaShop->getGithubXmlUrl());
             file_put_contents($path . '/prestashop.xml', $response->toStream());
         }

--- a/src/Util/PrestaShopUtils.php
+++ b/src/Util/PrestaShopUtils.php
@@ -8,7 +8,6 @@ use App\Exception\NoAssetException;
 use App\Model\PrestaShop;
 use Github\Client as GithubClient;
 use Google\Cloud\Storage\Bucket;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
@@ -16,6 +15,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\ParserFactory;
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Throwable;
 use ZipArchive;
 

--- a/src/Util/PrestaShopUtils.php
+++ b/src/Util/PrestaShopUtils.php
@@ -8,7 +8,7 @@ use App\Exception\NoAssetException;
 use App\Model\PrestaShop;
 use Github\Client as GithubClient;
 use Google\Cloud\Storage\Bucket;
-use GuzzleHttp\Client;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
@@ -22,7 +22,7 @@ use ZipArchive;
 class PrestaShopUtils
 {
     private GithubClient $githubClient;
-    private Client $client;
+    private HttpClientInterface $client;
     private Bucket $bucket;
     private PublicDownloadUrlProvider $publicDownloadUrlProvider;
     private ReleaseNoteUtils $releaseNoteUtils;
@@ -36,7 +36,7 @@ class PrestaShopUtils
 
     public function __construct(
         GithubClient $githubClient,
-        Client $client,
+        HttpClientInterface $client,
         Bucket $bucket,
         PublicDownloadUrlProvider $publicDownloadUrlProvider,
         ReleaseNoteUtils $releaseNoteUtils,
@@ -63,12 +63,12 @@ class PrestaShopUtils
             throw new RuntimeException(sprintf('Unable to download PrestaShop %s zip because it has no Github url', $prestaShop->getVersion()));
         }
 
-        $response = $this->client->get($prestaShop->getGithubZipUrl());
-        file_put_contents($path . '/prestashop.zip', $response->getBody());
+        $response = $this->client->request('GET', $prestaShop->getGithubZipUrl());
+        file_put_contents($path . '/prestashop.zip', $response->toStream());
 
         if ($prestaShop->getGithubXmlUrl() !== null) {
-            $response = $this->client->get($prestaShop->getGithubXmlUrl());
-            file_put_contents($path . '/prestashop.xml', $response->getBody());
+            $response = $this->client->request('GET', $prestaShop->getGithubXmlUrl());
+            file_put_contents($path . '/prestashop.xml', $response->toStream());
         }
     }
 

--- a/tests/Command/GenerateJsonCommandTest.php
+++ b/tests/Command/GenerateJsonCommandTest.php
@@ -11,10 +11,10 @@ use App\Util\PrestaShopUtils;
 use App\Util\PublicDownloadUrlProvider;
 use App\Util\ReleaseNoteUtils;
 use Google\Cloud\Storage\Bucket;
-use GuzzleHttp\Client;
 use Psssst\ModuleParser;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class GenerateJsonCommandTest extends AbstractCommandTestCase
 {
@@ -33,7 +33,7 @@ class GenerateJsonCommandTest extends AbstractCommandTestCase
 
         $moduleUtils = new ModuleUtils(
             new ModuleParser(),
-            $this->createMock(Client::class),
+            $this->createMock(HttpClientInterface::class),
             $githubClient,
             $bucket,
             $urlProvider,
@@ -43,7 +43,7 @@ class GenerateJsonCommandTest extends AbstractCommandTestCase
         );
         $prestaShopUtils = new PrestaShopUtils(
             $githubClient,
-            $this->createMock(Client::class),
+            $this->createMock(HttpClientInterface::class),
             $bucket,
             $urlProvider,
             new ReleaseNoteUtils(),

--- a/tests/Command/UpdateModuleConfigFilesCommandTest.php
+++ b/tests/Command/UpdateModuleConfigFilesCommandTest.php
@@ -10,10 +10,10 @@ use App\Util\PublicDownloadUrlProvider;
 use Github\Api\Repository\Contents;
 use Github\Client as GithubClient;
 use Google\Cloud\Storage\Bucket;
-use GuzzleHttp\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psssst\ModuleParser;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class UpdateModuleConfigFilesCommandTest extends AbstractCommandTestCase
 {
@@ -32,7 +32,7 @@ class UpdateModuleConfigFilesCommandTest extends AbstractCommandTestCase
 
         $moduleUtils = new ModuleUtils(
             new ModuleParser(),
-            $this->createMock(Client::class),
+            $this->createMock(HttpClientInterface::class),
             $this->githubClient,
             $this->createMock(Bucket::class),
             new PublicDownloadUrlProvider(''),

--- a/tests/Util/ModuleUtilsTest.php
+++ b/tests/Util/ModuleUtilsTest.php
@@ -8,8 +8,8 @@ use App\Model\Version;
 use App\Util\ModuleUtils;
 use App\Util\PublicDownloadUrlProvider;
 use Google\Cloud\Storage\Bucket;
-use GuzzleHttp\Client;
 use Psssst\ModuleParser;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Tests\AbstractMockedGithubClientTestCase;
 
 class ModuleUtilsTest extends AbstractMockedGithubClientTestCase
@@ -25,7 +25,7 @@ class ModuleUtilsTest extends AbstractMockedGithubClientTestCase
     ): void {
         $moduleUtils = new ModuleUtils(
             new ModuleParser(),
-            $this->createMock(Client::class),
+            $this->createMock(HttpClientInterface::class),
             $this->createGithubClientMock(),
             $this->createMock(Bucket::class),
             new PublicDownloadUrlProvider(''),

--- a/tests/Util/PrestaShopUtilsTest.php
+++ b/tests/Util/PrestaShopUtilsTest.php
@@ -8,7 +8,7 @@ use App\Util\PrestaShopUtils;
 use App\Util\PublicDownloadUrlProvider;
 use App\Util\ReleaseNoteUtils;
 use Google\Cloud\Storage\Bucket;
-use GuzzleHttp\Client;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Tests\AbstractMockedGithubClientTestCase;
 
 class PrestaShopUtilsTest extends AbstractMockedGithubClientTestCase
@@ -20,7 +20,7 @@ class PrestaShopUtilsTest extends AbstractMockedGithubClientTestCase
     {
         $prestaShopUtil = new PrestaShopUtils(
             $this->createGithubClientMock(),
-            $this->createMock(Client::class),
+            $this->createMock(HttpClientInterface::class),
             $this->createMock(Bucket::class),
             new PublicDownloadUrlProvider(''),
             new ReleaseNoteUtils(),


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Replaced GuzzleHttp with Symfony HttpClient across the codebase to unify HTTP client usage. Updated relevant constructors, method calls, and configurations accordingly. Added Symfony HttpClient to composer dependencies and updated the services configuration.
| Type?             | bug fix / improvement
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | check bucket after workflow to integration run.