### PR TITLE
Display output in logs as soon as they are written

### DIFF
--- a/cloud.Dockerfile
+++ b/cloud.Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /var/www/html
 COPY --from=builder /app/ /var/www/html
 
 RUN echo "<?php echo 'Healthcheck';" > /var/www/html/index.php
-RUN echo "<?php \$output = shell_exec('bin/console run'); echo '<pre>'.\$output.'</pre>';" > /var/www/html/run.php
+RUN echo "<?php system('bin/console run');" > /var/www/html/run.php
 
 RUN chown -R www-data:www-data /var/www
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When looking at the logs of the cron taks, we get the log AFTER the HTTP response. This PR aims to display them while the command is being run. 
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Check logs on Google Cloud
