### PR TITLE
Refresh all version without the distribution property set

### DIFF
--- a/src/Util/PrestaShopUtils.php
+++ b/src/Util/PrestaShopUtils.php
@@ -214,7 +214,7 @@ abstract class PrestaShopUtils
             if (!$this->isVersionGreaterThanOrEqualToMin($prestaShopJson['version'])) {
                 continue;
             }
-            if (empty($prestaShopJson['xml_download_url']) || empty($prestaShopJson['zip_md5'])) {
+            if (empty($prestaShopJson['xml_download_url']) || empty($prestaShopJson['zip_md5']) || empty($prestaShopJson['distribution'])) {
                 continue;
             }
             $prestashop = new PrestaShop(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In order to avoid dropping the whole contents of the bucket, we can define how a release can be considered as valid. It will be ignored if a mandatory property is missing, making it refreshed at the next run.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Run it based on the contents of the production bucket. You must generate a new prestashop.json file with all the versions in it and all the new properties set.
