### PR TITLE
Refresh the details of a stable version if it lacks its release notes

### DIFF
--- a/src/Util/PrestaShopUtils.php
+++ b/src/Util/PrestaShopUtils.php
@@ -215,6 +215,11 @@ abstract class PrestaShopUtils
                 continue;
             }
             if (empty($prestaShopJson['xml_download_url']) || empty($prestaShopJson['zip_md5']) || empty($prestaShopJson['distribution'])) {
+                // Refresh the details if a version was added from an old version of the API
+                continue;
+            }
+            if (empty($prestaShopJson['release_notes_url']) && $prestaShopJson['stability'] === 'stable') {
+                // Refresh the details if a stable version lacks its release notes.
                 continue;
             }
             $prestashop = new PrestaShop(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When releasing a new version of PrestaShop in the future, it is possible a new release is pushed on GitHub and made available on Distribution API before its release notes are being added. If this happens, we allow the API to refresh the data in the hope to add the link once available in the releaseNotes.json file.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Set the property `release_notes_url` of one stable release of PrestaShop as `null`, then run the command to generate the json files. The list must be updated by adding the release note you just deleted.