### PR TITLE
Enable updates to PrestaShop v9

### DIFF
--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -2,14 +2,14 @@
   "prestashop": [
     {
       "prestashop_min": "1.7.0.0",
-      "prestashop_max": "8.2.1",
+      "prestashop_max": "9.0.0",
       "autoupgrade_recommended": {
-        "last_version": "7.0.0",
+        "last_version": "7.1.0",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.0.0/autoupgrade-v7.0.0.zip",
-          "md5": "c0d83aea9dbb03d7f2f698d011144d43"
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.1.0/autoupgrade-v7.1.0.zip",
+          "md5": "974024b034c55773ee2df93e18fded42"
         },
-        "changelog": "https://build.prestashop-project.org/news/2025/autoupgrade-v7.0-release/"
+        "changelog": "https://github.com/PrestaShop/autoupgrade/releases/tag/v7.1.0"
       }
     },
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | PrestaShop v9 is released! This PR enables the updates to this new version and provides the freshly release Update Assistant 7.1 as the recommended module.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Deploy on integration and check the module suggests updating to PrestaShop v9.