### PR TITLE
Prevent updates to 8.2.2

### DIFF
--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -2,6 +2,18 @@
   "prestashop": [
     {
       "prestashop_min": "1.7.0.0",
+      "prestashop_max": "8.2.1",
+      "autoupgrade_recommended": {
+        "last_version": "7.1.0",
+        "download": {
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.1.0/autoupgrade-v7.1.0.zip",
+          "md5": "974024b034c55773ee2df93e18fded42"
+        },
+        "changelog": "https://github.com/PrestaShop/autoupgrade/releases/tag/v7.1.0"
+      }
+    },
+    {
+      "prestashop_min": "9.0.0",
       "prestashop_max": "9.0.0",
       "autoupgrade_recommended": {
         "last_version": "7.1.0",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update assistant is not ready yet. This PR prevents updates to target this version, otherwise marchants won't have their database up to date.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Update to 8.2.2 is not shown
