### PR TITLE
Enable updates to PS 8.2.2 and update recommended Update Assistant version

### DIFF
--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -2,26 +2,24 @@
   "prestashop": [
     {
       "prestashop_min": "1.7.0.0",
-      "prestashop_max": "8.2.1",
+      "prestashop_max": "8.2.2",
       "autoupgrade_recommended": {
-        "last_version": "7.1.0",
+        "last_version": "7.3.0",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.1.0/autoupgrade-v7.1.0.zip",
-          "md5": "974024b034c55773ee2df93e18fded42"
-        },
-        "changelog": "https://github.com/PrestaShop/autoupgrade/releases/tag/v7.1.0"
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.3.0/autoupgrade-v7.3.0.zip",
+          "md5": "48ced9086bac4f2e2266c3d20505e58c"
+        }
       }
     },
     {
       "prestashop_min": "9.0.0",
       "prestashop_max": "9.0.0",
       "autoupgrade_recommended": {
-        "last_version": "7.1.0",
+        "last_version": "7.3.0",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.1.0/autoupgrade-v7.1.0.zip",
-          "md5": "974024b034c55773ee2df93e18fded42"
-        },
-        "changelog": "https://github.com/PrestaShop/autoupgrade/releases/tag/v7.1.0"
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.3.0/autoupgrade-v7.3.0.zip",
+          "md5": "48ced9086bac4f2e2266c3d20505e58c"
+        }
       }
     },
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Now that Update Assistant 7.3.0 is published, we can allow the updates to PS 8.2.2
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Updates to v8.2.2 are possible and an update of the module is recommended