### PR TITLE
Add "recommended" property for autoupgrade.json

### DIFF
--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -3,6 +3,7 @@
     {
       "prestashop_min": "1.7.0.0",
       "prestashop_max": "8.2.3",
+      "recommended": true,
       "autoupgrade_recommended": {
         "last_version": "7.3.0",
         "download": {
@@ -14,6 +15,7 @@
     {
       "prestashop_min": "9.0.0",
       "prestashop_max": "9.0.0",
+      "recommended": false,
       "autoupgrade_recommended": {
         "last_version": "7.3.0",
         "download": {
@@ -25,6 +27,7 @@
     {
       "prestashop_min": "1.6.0.0",
       "prestashop_max": "1.7.8.11",
+      "recommended": true,
       "autoupgrade_recommended": {
         "last_version": "4.16.4",
         "download": {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add "recommended" property for autoupgrade.json to prevent certain PrestaShop versions from being "recommended" for updates.</br>
This is necessary to avoid issues such as backward compatibility problems and regressions that were seen after the release of PrestaShop 9. By default, a new recommended property should be set to true. When set to false, it will remove the version from the notification modal unless the user is already within that version range.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | see autoupgrade.json in Integration envirionnement