### PR TITLE
Display all the Classic versions that exist for a same PrestaShop release

### DIFF
--- a/src/Command/GenerateJsonCommand.php
+++ b/src/Command/GenerateJsonCommand.php
@@ -282,7 +282,12 @@ class GenerateJsonCommand extends Command
                 break;
         }
 
-        return $isChannel && ($current === null || version_compare($new->getVersion(), $current->getVersion(), '>'));
+        return $isChannel && (
+            $current === null || (
+                version_compare($new->getVersion(), $current->getVersion(), '>=')
+                && version_compare($new->getDistributionVersion() ?? '0', $current->getDistributionVersion() ?? '0', '>=')
+            )
+        );
     }
 
     /**
@@ -299,8 +304,8 @@ class GenerateJsonCommand extends Command
         $filtered = [];
 
         foreach ($versions as $version) {
-            // Build a unique key using version number and stability (e.g. "9.0.0|beta")
-            $key = $version->getVersion() . '|' . $version->getStability();
+            // Build a unique key using version number, stability, and distribution version (e.g. "9.0.0|beta|2.0")
+            $key = $version->getVersion() . '|' . $version->getStability() . '|' . $version->getDistributionVersion();
 
             // If the key is not yet in the result, just store it
             if (!isset($filtered[$key])) {
@@ -315,6 +320,8 @@ class GenerateJsonCommand extends Command
         }
 
         // Re-index the array numerically
+        rsort($filtered);
+
         return array_values($filtered);
     }
 }

--- a/tests/ressources/json/prestashop.json
+++ b/tests/ressources/json/prestashop.json
@@ -1,6 +1,30 @@
 [
   {
     "version": "9.0.0",
+    "distribution": "open_source",
+    "distribution_version": null,
+    "php_max_version": "8.4",
+    "php_min_version": "8.1",
+    "release_notes_url": "https://build.prestashop-project.org/news/2025/prestashop-9-0-available/",
+    "stability": "stable",
+    "xml_download_url": "\/assets\/prestashop\/9.0.0\/prestashop.xml",
+    "zip_download_url": "\/assets\/prestashop\/9.0.0\/prestashop.zip",
+    "zip_md5": "07f0a71a301e966447e3419143cdf570"
+  },
+  {
+    "version": "9.0.0",
+    "distribution": "classic",
+    "distribution_version": "3.0",
+    "php_max_version": "8.4",
+    "php_min_version": "8.1",
+    "release_notes_url": "https://build.prestashop-project.org/news/2025/prestashop-9-0-available/",
+    "stability": "stable",
+    "xml_download_url": "\/assets\/prestashop-classic\/9.0.0-3.0\/prestashop.xml",
+    "zip_download_url": "\/assets\/prestashop-classic\/9.0.0-3.0\/prestashop.zip",
+    "zip_md5": "07f0a71a301e966447e3419143cdf570"
+  },
+  {
+    "version": "9.0.0",
     "distribution": "classic",
     "distribution_version": "0.2",
     "php_max_version": "8.4",

--- a/tests/ressources/json/prestashop/stable.json
+++ b/tests/ressources/json/prestashop/stable.json
@@ -1,12 +1,12 @@
 {
   "version": "9.0.0",
   "distribution": "classic",
-  "distribution_version": "0.2",
+  "distribution_version": "3.0",
   "php_max_version": "8.4",
   "php_min_version": "8.1",
   "release_notes_url": "https://build.prestashop-project.org/news/2025/prestashop-9-0-available/",
   "stability": "stable",
-  "xml_download_url": "\/assets\/prestashop-classic\/9.0.0-0.2\/prestashop.xml",
-  "zip_download_url": "\/assets\/prestashop-classic\/9.0.0-0.2\/prestashop.zip",
+  "xml_download_url": "\/assets\/prestashop-classic\/9.0.0-3.0\/prestashop.xml",
+  "zip_download_url": "\/assets\/prestashop-classic\/9.0.0-3.0\/prestashop.zip",
   "zip_md5": "07f0a71a301e966447e3419143cdf570"
  }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The current state of the URL https://api.prestashop-project.org/prestashop is unable to show the two existing classic releases of PrestaShop 9.0.2 (versions 2.0 and 2.1). Some regenerations of the file use the classic version 2.1, sometimes 2.0 by mistake. This can lead to issues with Update Assistant where the version distributed is the latest, and autogenerated PRs on the docker repository opened by mistake as well (i.e https://github.com/PrestaShop/docker/pull/473) 
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Running the command `bin/console generateJson` must generate the prestashop.json with the proper combination of versions 9.0.2

```json
[truncated]
    {
        "version": "9.0.2",
        "distribution": "classic",
        "distribution_version": "2.1",
        "php_max_version": "8.4",
        "php_min_version": "8.1",
        "zip_download_url": "https:\/\/integration-api.prestashop-project.org\/assets\/prestashop-classic\/9.0.2-2.1\/prestashop.zip",
        "zip_md5": "2307cb8e068745c7afcc7d7673869e12",
        "xml_download_url": "https:\/\/integration-api.prestashop-project.org\/assets\/prestashop-classic\/9.0.2-2.1\/prestashop.xml",
        "stability": "stable",
        "release_notes_url": "https:\/\/build.prestashop-project.org\/news\/2025\/prestashop-9-0-2-maintenance-release\/"
    },
    {
        "version": "9.0.2",
        "distribution": "classic",
        "distribution_version": "2.0",
        "php_max_version": "8.4",
        "php_min_version": "8.1",
        "zip_download_url": "https:\/\/integration-api.prestashop-project.org\/assets\/prestashop-classic\/9.0.2-2.0\/prestashop.zip",
        "zip_md5": "6603f40e0149e5ff47d84042d6936766",
        "xml_download_url": "https:\/\/integration-api.prestashop-project.org\/assets\/prestashop-classic\/9.0.2-2.0\/prestashop.xml",
        "stability": "stable",
        "release_notes_url": "https:\/\/build.prestashop-project.org\/news\/2025\/prestashop-9-0-2-maintenance-release\/"
    },
[truncated]
```