### PR TITLE
chore: update autoupgrade version to 7.6.2

### DIFF
--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -8,7 +8,7 @@
         "last_version": "7.6.2",
         "download": {
           "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.2/autoupgrade-v7.6.2.zip",
-          "md5": "366e6ee52772324666082123fa90ed3b"
+          "md5": "8fa5ec892c15489da26e80d9061fd7ff"
         }
       }
     },
@@ -20,7 +20,7 @@
         "last_version": "7.6.2",
         "download": {
           "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.2/autoupgrade-v7.6.2.zip",
-          "md5": "366e6ee52772324666082123fa90ed3b"
+          "md5": "8fa5ec892c15489da26e80d9061fd7ff"
         }
       }
     },

--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -5,9 +5,9 @@
       "prestashop_max": "8.2.5",
       "recommended": true,
       "autoupgrade_recommended": {
-        "last_version": "7.6.0",
+        "last_version": "7.6.2",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.0/autoupgrade-v7.6.0.zip",
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.2/autoupgrade-v7.6.2.zip",
           "md5": "366e6ee52772324666082123fa90ed3b"
         }
       }
@@ -17,9 +17,9 @@
       "prestashop_max": "9.1.0",
       "recommended": false,
       "autoupgrade_recommended": {
-        "last_version": "7.5.1",
+        "last_version": "7.6.2",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.5.1/autoupgrade-v7.5.1.zip",
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.2/autoupgrade-v7.6.2.zip",
           "md5": "366e6ee52772324666082123fa90ed3b"
         }
       }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update autoupgrade.json according his latest release 7.6.2 ([WIP](https://github.com/PrestaShop/autoupgrade/milestone/61)) 
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | @PrestaShopCorp
| How to test?      | N/A

> [!WARNING]
Do not merge before 7.6.2 is released we need to update `md5` fields.
