### PR TITLE
Add release notes of PrestaShop 8.2.6 and 9.1.1

### DIFF
--- a/resources/json/releaseNotes.json
+++ b/resources/json/releaseNotes.json
@@ -1,4 +1,5 @@
 {
+  "9.1.1": "https://build.prestashop-project.org/news/2026/prestashop-9-1-1-security-release/",
   "9.1.0": "https://build.prestashop-project.org/news/2026/prestashop-9-1-0-available/",
   "9.1.0-beta.1": "https://build.prestashop-project.org/news/2026/prestashop-9-1-beta1/",
   "9.0.3": "https://build.prestashop-project.org/news/2026/prestashop-9-0-3-maintenance-release/",
@@ -7,6 +8,7 @@
   "9.0.0": "https://build.prestashop-project.org/news/2025/prestashop-9-0-available/",
   "9.0.0-rc.1": "https://build.prestashop-project.org/news/2025/prestashop-9-0-rc1/",
   "9.0.0-beta.1": "https://build.prestashop-project.org/news/2025/prestashop-9-0-beta-release/",
+  "8.2.6": "https://build.prestashop-project.org/news/2026/prestashop-8-2-6-security-release/",
   "8.2.5": "https://build.prestashop-project.org/news/2026/prestashop-8-2-5-maintenance-release/",
   "8.2.4": "https://build.prestashop-project.org/news/2026/prestashop-8-2-4-maintenance-release/",
   "8.2.3": "https://build.prestashop-project.org/news/2025/prestashop-8-2-3-security-release/",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adding the release notes of recent releases of PrestaShop 8.2.6 and 9.1.1, so the links can be displayed on Update Assistant on the version selection page and the notification modal.
| Type?             |improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Json file is valid
