### PR TITLE
Enable updates to PS 9.1.2 with Update Assistant 7.6.5

### DIFF
--- a/public/json/autoupgrade.json
+++ b/public/json/autoupgrade.json
@@ -5,22 +5,22 @@
       "prestashop_max": "8.2.6",
       "recommended": true,
       "autoupgrade_recommended": {
-        "last_version": "7.6.3",
+        "last_version": "7.6.5",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.3/autoupgrade-v7.6.3.zip",
-          "md5": "2502338c49e9ead1712768523ecdcd07"
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.5/autoupgrade-v7.6.5.zip",
+          "md5": "1a27e3d35af3191fc5af441c4e634f1d"
         }
       }
     },
     {
       "prestashop_min": "9.0.0",
-      "prestashop_max": "9.1.1",
+      "prestashop_max": "9.1.2",
       "recommended": false,
       "autoupgrade_recommended": {
-        "last_version": "7.6.3",
+        "last_version": "7.6.5",
         "download": {
-          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.3/autoupgrade-v7.6.3.zip",
-          "md5": "2502338c49e9ead1712768523ecdcd07"
+          "link": "https://github.com/PrestaShop/autoupgrade/releases/download/v7.6.5/autoupgrade-v7.6.5.zip",
+          "md5": "1a27e3d35af3191fc5af441c4e634f1d"
         }
       }
     },

--- a/resources/json/releaseNotes.json
+++ b/resources/json/releaseNotes.json
@@ -1,4 +1,5 @@
 {
+  "9.1.2": "https://build.prestashop-project.org/news/2026/prestashop-9-1-2-maintenance-release/",
   "9.1.1": "https://build.prestashop-project.org/news/2026/prestashop-9-1-1-security-release/",
   "9.1.0": "https://build.prestashop-project.org/news/2026/prestashop-9-1-0-available/",
   "9.1.0-beta.1": "https://build.prestashop-project.org/news/2026/prestashop-9-1-beta1/",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Now that Update Assistant 7.6.5 is released, we can allow updates to PrestaShop 9.1.2.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | /
