### PR TITLE
Add release notes for PrestaShop 8.2.7 and 9.1.4

### DIFF
--- a/resources/json/releaseNotes.json
+++ b/resources/json/releaseNotes.json
@@ -1,4 +1,5 @@
 {
+  "9.1.4": "https://build.prestashop-project.org/news/2026/prestashop-9-1-4-and-8-2-7-available/",
   "9.1.3": "https://build.prestashop-project.org/news/2026/prestashop-9-1-3-maintenance-release/",
   "9.1.2": "https://build.prestashop-project.org/news/2026/prestashop-9-1-2-maintenance-release/",
   "9.1.1": "https://build.prestashop-project.org/news/2026/prestashop-9-1-1-security-release/",
@@ -10,6 +11,7 @@
   "9.0.0": "https://build.prestashop-project.org/news/2025/prestashop-9-0-available/",
   "9.0.0-rc.1": "https://build.prestashop-project.org/news/2025/prestashop-9-0-rc1/",
   "9.0.0-beta.1": "https://build.prestashop-project.org/news/2025/prestashop-9-0-beta-release/",
+  "8.2.7": "https://build.prestashop-project.org/news/2026/prestashop-9-1-4-and-8-2-7-available/",
   "8.2.6": "https://build.prestashop-project.org/news/2026/prestashop-8-2-6-security-release/",
   "8.2.5": "https://build.prestashop-project.org/news/2026/prestashop-8-2-5-maintenance-release/",
   "8.2.4": "https://build.prestashop-project.org/news/2026/prestashop-8-2-4-maintenance-release/",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adding the release notes of recent releases of PrestaShop 8.2.7 and 9.1.4, so the links can be displayed on Update Assistant on the version selection page and the notification modal.
| Type?             |improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | Json file is valid
